### PR TITLE
Improve error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -272,7 +272,19 @@ module.exports = function (app) {
     },
 
     start: function (options) {
-      clientP = skToInflux.influxClientP(options)
+
+      let retryTimeout = 1000
+      function connectToInflux() {
+        clientP = skToInflux.influxClientP(options)
+        clientP.catch(err => {
+          console.error(`Error connecting to InfluxDb, retrying in ${retryTimeout} ms`)
+          setTimeout(() => {
+            connectToInflux()
+          }, retryTimeout)
+          retryTimeout *= retryTimeout > 30 * 1000 ? 1 : 2
+        })
+      }
+      connectToInflux()
 
       if ( app.registerHistoryProvider )
         app.registerHistoryProvider(plugin)

--- a/index.js
+++ b/index.js
@@ -311,9 +311,9 @@ module.exports = function (app) {
             lastWriteTime = now
             clientP
               .then(client => {
-                client.writePoints(accumulatedPoints)
+                const thePoints = accumulatedPoints
                 accumulatedPoints = []
-
+                return client.writePoints(thePoints)
               })
               .catch(error => {
                 logError(error)


### PR DESCRIPTION
- handle properly the situation where InfluxDb writePoints fails instead of getting an error message for an unhandled Promise rejection
- handle correctly the situation where InfluxDb is not available when we start: add retry