### PR TITLE
fix: always save empty paths (#29)

### DIFF
--- a/skToInflux.js
+++ b/skToInflux.js
@@ -161,7 +161,7 @@ function shouldStorePositionNow(delta, recordTrack, time) {
 function shouldStoreNow(delta, path, shouldStore, time, resolution) {
   return shouldStore(path)
     && (!lastUpdates[delta.context] || !lastUpdates[delta.context][path] ||
-        time - lastUpdates[delta.context][path] > resolution )
+        time - lastUpdates[delta.context][path] > resolution || path == "" )
 }
 
   

--- a/skToInflux.js
+++ b/skToInflux.js
@@ -161,7 +161,7 @@ function shouldStorePositionNow(delta, recordTrack, time) {
 function shouldStoreNow(delta, path, shouldStore, time, resolution) {
   return shouldStore(path)
     && (!lastUpdates[delta.context] || !lastUpdates[delta.context][path] ||
-        time - lastUpdates[delta.context][path] > resolution || path == "" )
+        time - lastUpdates[delta.context][path] > resolution || path == '' )
 }
 
   


### PR DESCRIPTION
always save deltas with empty path so a single delta can contain multiple empty paths and they will all be saved