### PR TITLE
feature: add option to store lat and lon as separate measurements

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Adding support for non-self data would be pretty easy by adding context as Influ
 If enabled by black/whitelist configuration `navigation.position` updates are written to the db no more frequently than once per second. More frequent updates are simply ignored.
 
 The coordinates are written as `[lon, lat]` strings for minimal postprocessing in GeoJSON conversion.
+Optionally, coordinates can be written separately to database. This enable location data to be used in various ways e.g. in Grafana (mapping, functions, ...).
 
 The plugin creates `/signalk/vX/api/self/track` endpoint that accepts two parameters:
 - timespan in the xxxY format, where xxx is a Number and Y one of 

--- a/index.js
+++ b/index.js
@@ -245,6 +245,12 @@ module.exports = function (app) {
           description: "When enabled the vessels position will be stored",
           default: false
         },
+        separateLatLon: {
+          type: "boolean",
+          title: "Latitude and Longitude as a separate measurements to Influxdb",
+          description: "Enable location data to be used in various ways e.g. in Grafana (mapping, functions, ...)",
+          default: false
+        },
         overrideTimeWithNow: {
           type: "boolean",
           title: "Override time with current timestamp",
@@ -324,7 +330,7 @@ module.exports = function (app) {
           }
         }
       }
-      let deltaToPoints = skToInflux.deltaToPointsConverter(selfContext, options.recordTrack, shouldStore, options.resolution || 200, options.storeOthers, !options.overrideTimeWithNow)
+      let deltaToPoints = skToInflux.deltaToPointsConverter(selfContext, options.recordTrack, options.separateLatLon, shouldStore, options.resolution || 200, options.storeOthers, !options.overrideTimeWithNow)
       let accumulatedPoints = []
       let lastWriteTime = Date.now()
       let batchWriteInterval = (typeof options.batchWriteInterval === 'undefined' ? 10 : options.batchWriteInterval) * 1000

--- a/index.js
+++ b/index.js
@@ -247,7 +247,7 @@ module.exports = function (app) {
         },
         separateLatLon: {
           type: "boolean",
-          title: "Latitude and Longitude as a separate measurements to Influxdb",
+          title: "Latitude and Longitude as separate measurements to Influxdb",
           description: "Enable location data to be used in various ways e.g. in Grafana (mapping, functions, ...)",
           default: false
         },

--- a/skToInflux.js
+++ b/skToInflux.js
@@ -64,7 +64,9 @@ module.exports = {
                       jsonValue: JSON.stringify({
                         longitude: pathValue.value.longitude,
                         latitude: pathValue.value.latitude
-                      })
+                      }),
+                      lon: pathValue.value.longitude,
+                      lat: pathValue.value.latitude
                     }
                   }
                   acc.push(point)

--- a/skToInflux.js
+++ b/skToInflux.js
@@ -34,6 +34,7 @@ module.exports = {
   deltaToPointsConverter: (
     selfContext,
     recordTrack,
+    separateLatLon,
     shouldStore,
     resolution,
     storeOthers,
@@ -65,12 +66,23 @@ module.exports = {
                         longitude: pathValue.value.longitude,
                         latitude: pathValue.value.latitude
                       }),
-                      lon: pathValue.value.longitude,
-                      lat: pathValue.value.latitude
                     }
                   }
                   acc.push(point)
                   lastPositionStored[delta.context] = time
+
+                  if (separateLatLon) {
+                    const point = {
+                      measurement: pathValue.path,
+                      tags: tags,
+                      timestamp: date,
+                      fields: {
+                          lon: pathValue.value.longitude,
+                          lat: pathValue.value.latitude
+                      }
+                    }
+                    acc.push(point)
+                  }
                 }
               } else if (shouldStoreNow(delta, pathValue.path, shouldStore, time, resolution)) {
                 if ( !lastUpdates[delta.context] )


### PR DESCRIPTION
Add possibility to use Signalk location data in Grafana map plugins (e.g. TrackMap and Track Map).