### PR TITLE
feature: per source throttling and write timestamp pruning

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-const { deltaToPointsConverter, influxClientP } = require('./skToInflux')
+const { deltaToPointsConverter, influxClientP, pruneTimestamps } = require('./skToInflux')
 
 module.exports = function (app) {
   const logError = app.error || ((err) => {console.error(err)})
@@ -352,8 +352,12 @@ module.exports = function (app) {
         }
       }
       app.signalk.on('delta', handleDelta)
+      const pruneInterval = setInterval(() => {
+        pruneTimestamps(1000 * options.resolution)
+      }, 100 * options.resolution)
       unsubscribes.push(() => {
         app.signalk.removeListener('delta', handleDelta)
+        clearInterval(pruneInterval)
       })
     },
     stop: function () {

--- a/index.js
+++ b/index.js
@@ -13,10 +13,7 @@
  * limitations under the License.
  */
 
-const Bacon = require('baconjs')
-const debug = require('debug')('signalk-to-influxdb')
-const util = require('util')
-const skToInflux = require('./skToInflux')
+const { deltaToPointsConverter, influxClientP } = require('./skToInflux')
 
 module.exports = function (app) {
   const logError = app.error || ((err) => {console.error(err)})
@@ -295,7 +292,7 @@ module.exports = function (app) {
           clientP.catch(() =>{})
           return
         }
-        clientP = skToInflux.influxClientP(options)
+        clientP = influxClientP(options)
         clientP.catch(err => {
           console.error(`Error connecting to InfluxDb, retrying in ${retryTimeout} ms`)
           setTimeout(() => {
@@ -330,7 +327,7 @@ module.exports = function (app) {
           }
         }
       }
-      let deltaToPoints = skToInflux.deltaToPointsConverter(selfContext, options.recordTrack, options.separateLatLon, shouldStore, options.resolution || 200, options.storeOthers, !options.overrideTimeWithNow)
+      let deltaToPoints = deltaToPointsConverter(selfContext, options.recordTrack, options.separateLatLon, shouldStore, options.resolution || 200, options.storeOthers, !options.overrideTimeWithNow)
       let accumulatedPoints = []
       let lastWriteTime = Date.now()
       let batchWriteInterval = (typeof options.batchWriteInterval === 'undefined' ? 10 : options.batchWriteInterval) * 1000

--- a/skToInflux.js
+++ b/skToInflux.js
@@ -171,7 +171,22 @@ module.exports = {
           reject(err)
         })
     })
+  },
+  pruneTimestamps(maxAge) {
+    clearContextTimestamps(lastUpdates, maxAge)
+    clearContextTimestamps(lastPositionStored, maxAge)
   }
+}
+
+function clearContextTimestamps(holder, maxAge) {
+  Object.keys(holder).forEach(context => {
+    const newestTimestamp = Object.keys(holder[context]).reduce((acc, key) => {
+      return Math.max(  acc, holder[context][key])
+    }, 0)
+    if (Date.now() - maxAge > newestTimestamp) {
+      delete holder[context]
+    }
+  })
 }
 
 function shouldStorePositionNow(delta, sourceId, time) {

--- a/skToInflux.js
+++ b/skToInflux.js
@@ -22,9 +22,9 @@ var lastUpdates = {}
 var lastPositionStored = {}
 
 function addSource(update, tags) {
-  if ( update['$source'] ) {
+  if (update['$source']) {
     tags.source = update['$source']
-  } else if ( update['source'] ) {
+  } else if (update['source']) {
     tags.source = getSourceId(update['source'])
   }
   return tags
@@ -41,7 +41,7 @@ module.exports = {
     honorDeltaTimestamp = true
   ) => {
     return delta => {
-    
+
       if (delta.context === 'vessels.self') {
         delta.context = selfContext
       }
@@ -54,7 +54,7 @@ module.exports = {
             let tags = addSource(update, { context: delta.context })
 
             update.values.reduce((acc, pathValue) => {
-     
+
               if (pathValue.path === 'navigation.position') {
                 if (recordTrack && shouldStorePositionNow(delta, tags.source, time)) {
                   const point = {
@@ -75,8 +75,8 @@ module.exports = {
                       tags: tags,
                       timestamp: date,
                       fields: {
-                          lon: pathValue.value.longitude,
-                          lat: pathValue.value.latitude
+                        lon: pathValue.value.longitude,
+                        lat: pathValue.value.latitude
                       }
                     }
                     acc.push(point)
@@ -160,7 +160,7 @@ module.exports = {
           debug('Connected')
           if (names.includes(database)) {
             resolve(client)
-         } else {
+          } else {
             client.createDatabase(database).then(result => {
               debug('Created InfluxDb database ' + database)
               resolve(client)
@@ -187,11 +187,11 @@ function shouldStoreNow(delta, pathAndSource, time, resolution) {
       time - lastUpdates[delta.context][pathAndSource] > resolution)
 }
 
-  
+
 function storeAttitude(date, pathValue, tags, acc) {
   ['pitch', 'roll', 'yaw'].forEach(key => {
     if (typeof pathValue.value[key] === 'number' &&
-        !isNaN(pathValue.value[key])) {
+      !isNaN(pathValue.value[key])) {
       acc.push({
         measurement: `navigation.attitude.${key}`,
         timestamp: date,


### PR DESCRIPTION
This PR changes write throttling per _resolution_ configuration parameter so that data from each source is throttled separately.

It also adds a pruning job that removes stale timestamps that are stored per context, in case contexts are no longer active.


