### PR TITLE
fix: History api date formatting in query

### DIFF
--- a/src/HistoryAPI.ts
+++ b/src/HistoryAPI.ts
@@ -66,10 +66,12 @@ async function getPaths(
   to: ZonedDateTime,
   debug: (s: string) => void,
   req: Request
-) :Promise<string[]> {
+): Promise<string[]> {
   const query = `SHOW MEASUREMENTS`;
   console.log(query);
-  return influx.then((i) => i.query(query)).then((d) => d.map((r:any) => r.name));
+  return influx
+    .then((i) => i.query(query))
+    .then((d) => d.map((r: any) => r.name));
 }
 
 interface ValuesResult {

--- a/src/HistoryAPI.ts
+++ b/src/HistoryAPI.ts
@@ -1,4 +1,4 @@
-import { ZonedDateTime } from "@js-joda/core";
+import { DateTimeFormatter, ZonedDateTime } from "@js-joda/core";
 import Debug from "debug";
 
 import {
@@ -116,7 +116,9 @@ async function getValues(
       WHERE
         "context" = '${context}'
         AND
-        time > '${from.toString()}' and time <= '${to.toString()}'
+        time > '${from.format(
+          DateTimeFormatter.ISO_LOCAL_DATE_TIME
+        )}Z' and time <= '${to.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)}Z'
       GROUP BY
         time(${Number(timeResolutionSeconds * 1000).toFixed(0)}ms)`
     )


### PR DESCRIPTION
toString() seems to be undeterministic, producing timestamps without
seconds that does not work in Influx.